### PR TITLE
make gimbal/chassis modes to be set based on UART pkg type

### DIFF
--- a/Devices/Devices.c/Jetson_Tx2.c
+++ b/Devices/Devices.c/Jetson_Tx2.c
@@ -10,6 +10,7 @@
  */
 
 #include "Jetson_Tx2.h"
+#include "State_Machine.h"
 
 void Jetson_Tx2_Handler(UART_HandleTypeDef *huart);
 void Jetson_Tx2_USART_Receive_DMA(UART_HandleTypeDef *huartx);
@@ -31,12 +32,26 @@ void Jetson_Tx2_Get_Data(void)
 		switch(Tx2_Data.Receiving.Frame_Type)
 		{
 			case 0:
+				// Sentry will send either an auto-aim or nav package, we will set the mode depending on the package
+				if (Chassis.Current_Mode != Auto_Aiming || Gimbal.Current_Mode != Auto_Aiming)
+				{
+					Chassis.Current_Mode = Auto_Aiming;
+					Gimbal.Current_Mode = Auto_Aiming;
+				}
+			
 				memcpy(&Tx2_Data.Receiving.Raw_Data.Data[0],&Tx2_Data.Rx_Buffer[4],8*sizeof(uint8_t));
 				Tx2_Data.Receiving.Auto_Aiming.Yaw = Tx2_Data.Receiving.Raw_Data.data[0];
 				Tx2_Data.Receiving.Auto_Aiming.Pitch = Tx2_Data.Receiving.Raw_Data.data[1];
 				break;
 			
 			case 1:
+				// Sentry will send either an auto-aim or nav package, we will set the mode depending on the package
+				if (Chassis.Current_Mode != Auto_Navigation || Gimbal.Current_Mode != Auto_Navigation)
+				{
+					Chassis.Current_Mode = Auto_Navigation;
+					Gimbal.Current_Mode = Auto_Navigation;
+				}
+			
 				memcpy(&Tx2_Data.Receiving.Raw_Data.Data[0],&Tx2_Data.Rx_Buffer[4],12*sizeof(uint8_t));
 				Tx2_Data.Receiving.Navigation.X_Vel = Tx2_Data.Receiving.Raw_Data.data[0];
 				Tx2_Data.Receiving.Navigation.Y_Vel = Tx2_Data.Receiving.Raw_Data.data[1];

--- a/HigherLevelApps/HigherLevelApps.c/State_Machine.c
+++ b/HigherLevelApps/HigherLevelApps.c/State_Machine.c
@@ -50,15 +50,17 @@ void Remote_Control_Update(void)
 		}
 		case (SWITCH_MID):
 		{
-			Chassis.Current_Mode = Auto_Aiming;
-			Gimbal.Current_Mode = Auto_Aiming;
+			// Do not set auto-aim or nav mode manually, already switches to correct mode based on UART package
+			// Chassis.Current_Mode = Auto_Aiming;
+			// Gimbal.Current_Mode = Auto_Aiming;
 
 			break;
 		}
 		case (SWITCH_UP):
 		{
-			Chassis.Current_Mode = Auto_Navigation;//Spin_Top;
-			Gimbal.Current_Mode = Auto_Navigation;
+			// Do not set auto-aim or nav mode manually, already switches to correct mode based on UART package
+			// Chassis.Current_Mode = Auto_Navigation;//Spin_Top;
+			// Gimbal.Current_Mode = Auto_Navigation;
 
 			//Chassis.Current_Mode = Follow_Gimbal;
 			//Gimbal.Current_Mode = Follow_Gimbal;

--- a/MDK-ARM/BoilerBot_Sentry_2023.uvprojx
+++ b/MDK-ARM/BoilerBot_Sentry_2023.uvprojx
@@ -16,7 +16,7 @@
         <TargetCommonOption>
           <Device>STM32F427IIHx</Device>
           <Vendor>STMicroelectronics</Vendor>
-          <PackID>Keil.STM32F4xx_DFP.2.17.0</PackID>
+          <PackID>Keil.STM32F4xx_DFP.2.17.1</PackID>
           <PackURL>https://www.keil.com/pack/</PackURL>
           <Cpu>IRAM(0x20000000-0x2002FFFF) IRAM2(0x10000000-0x1000FFFF) IROM(0x8000000-0x81FFFFF)  CLOCK(25000000) FPU2 CPUTYPE("Cortex-M4") TZ</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
@@ -134,7 +134,7 @@
             <RunIndependent>0</RunIndependent>
             <UpdateFlashBeforeDebugging>1</UpdateFlashBeforeDebugging>
             <Capability>1</Capability>
-            <DriverSelection>4101</DriverSelection>
+            <DriverSelection>4096</DriverSelection>
           </Flash1>
           <bUseTDR>1</bUseTDR>
           <Flash2>BIN\UL2CM3.DLL</Flash2>
@@ -186,7 +186,6 @@
             <RvdsVP>2</RvdsVP>
             <RvdsMve>0</RvdsMve>
             <RvdsCdeCp>0</RvdsCdeCp>
-            <nBranchProt>0</nBranchProt>
             <hadIRAM2>1</hadIRAM2>
             <hadIROM2>0</hadIROM2>
             <StupSel>8</StupSel>


### PR DESCRIPTION
- disable setting auto-aim / nav mode using remote control switches
- depending on uart pkg type (auto-aim or nav) update chassis and gimbal mode accordingly

needed so auto aim and nav can happen simultaneously without remote control.